### PR TITLE
fix AddTable parameter types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -257,6 +257,7 @@ declare module 'excelize-wasm' {
    * TableOptions directly maps the format settings of the table.
    */
   export type TableOptions = {
+    Range:              string;
     Name?:              string;
     StyleName?:         string;
     ShowFirstColumn?:   boolean;
@@ -981,7 +982,7 @@ declare module 'excelize-wasm' {
      * @param rangeRef The top-left and right-bottom cell range reference
      * @param opts The table options
      */
-    AddTable(sheet: string, rangeRef: string, opts: TableOptions): { error: string | null }
+    AddTable(sheet: string, opts: TableOptions): { error: string | null }
 
     /**
      * AutoFilter provides the method to add auto filter in a worksheet by


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

Current types are wrong.

## Description

<!--- Describe your changes in detail -->

if you do `wb.AddTable("Sheet1", "A1:B2");`  you get invalid arguments

in fact the program expects `wb.AddTable("Sheet1", { Range: "A1:B2");`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
