### PR TITLE
New function GetMergeCells has been added

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -415,11 +415,18 @@ func regInteropFunc(f *excelize.File, fn map[string]interface{}) interface{} {
 	return js.ValueOf(fn)
 }
 
+// regMergeCellFunc register functions that implemented MergeCell interface.
 func regMergeCellFunc(mergeCell *excelize.MergeCell, fn map[string]interface{}) interface{} {
 	for name, impl := range map[string]func(this js.Value, args []js.Value) interface{}{
-		"GetCellValue": GetCellValueFromMergeCell(mergeCell),
-		"GetStartAxis": GetStartAxisFromMergeCell(mergeCell),
-		"GetEndAxis":   GetEndAxisFromMergeCell(mergeCell),
+		"GetCellValue": func(this js.Value, args []js.Value) interface{} {
+			return js.ValueOf(mergeCell.GetCellValue())
+		},
+		"GetStartAxis": func(this js.Value, args []js.Value) interface{} {
+			return js.ValueOf(mergeCell.GetStartAxis())
+		},
+		"GetEndAxis": func(this js.Value, args []js.Value) interface{} {
+			return js.ValueOf(mergeCell.GetEndAxis())
+		},
 	} {
 		fn[name] = js.FuncOf(impl)
 	}
@@ -2073,7 +2080,8 @@ func GetHeaderFooter(f *excelize.File) func(this js.Value, args []js.Value) inte
 	}
 }
 
-// GetMergeCells provides a function to get all merged cells from a specific worksheet.
+// GetMergeCells provides a function to get all merged cells from a specific
+// worksheet.
 func GetMergeCells(f *excelize.File) func(this js.Value, args []js.Value) interface{} {
 	return func(this js.Value, args []js.Value) interface{} {
 		ret := map[string]interface{}{"mergeCells": []interface{}{}, "error": nil}
@@ -2491,27 +2499,6 @@ func GetSheetVisible(f *excelize.File) func(this js.Value, args []js.Value) inte
 			ret["error"] = err.Error()
 		}
 		return js.ValueOf(ret)
-	}
-}
-
-// GetCellValueFromMergeCell provides a function to get cell value from merge cell.
-func GetCellValueFromMergeCell(mergeCell *excelize.MergeCell) func(this js.Value, args []js.Value) interface{} {
-	return func(this js.Value, args []js.Value) interface{} {
-		return js.ValueOf(mergeCell.GetCellValue())
-	}
-}
-
-// GetStartAxisFromMergeCell provides a function to get start axis from merge cell.
-func GetStartAxisFromMergeCell(mergeCell *excelize.MergeCell) func(this js.Value, args []js.Value) interface{} {
-	return func(this js.Value, args []js.Value) interface{} {
-		return js.ValueOf(mergeCell.GetStartAxis())
-	}
-}
-
-// GetEndAxisFromMergeCell provides a function to get end axis from merge cell.
-func GetEndAxisFromMergeCell(mergeCell *excelize.MergeCell) func(this js.Value, args []js.Value) interface{} {
-	return func(this js.Value, args []js.Value) interface{} {
-		return js.ValueOf(mergeCell.GetEndAxis())
 	}
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -330,6 +330,7 @@ func regInteropFunc(f *excelize.File, fn map[string]interface{}) interface{} {
 		"GetDocProps":                 GetDocProps(f),
 		"GetFormControls":             GetFormControls(f),
 		"GetHeaderFooter":             GetHeaderFooter(f),
+		"GetMergeCells":               GetMergeCells(f),
 		"GetPageLayout":               GetPageLayout(f),
 		"GetPageMargins":              GetPageMargins(f),
 		"GetPanes":                    GetPanes(f),
@@ -408,6 +409,17 @@ func regInteropFunc(f *excelize.File, fn map[string]interface{}) interface{} {
 		"UnsetConditionalFormat":      UnsetConditionalFormat(f),
 		"UpdateLinkedValue":           UpdateLinkedValue(f),
 		"WriteToBuffer":               WriteToBuffer(f),
+	} {
+		fn[name] = js.FuncOf(impl)
+	}
+	return js.ValueOf(fn)
+}
+
+func regMergeCellFunc(mergeCell *excelize.MergeCell, fn map[string]interface{}) interface{} {
+	for name, impl := range map[string]func(this js.Value, args []js.Value) interface{}{
+		"GetCellValue": GetCellValueFromMergeCell(mergeCell),
+		"GetStartAxis": GetStartAxisFromMergeCell(mergeCell),
+		"GetEndAxis":   GetEndAxisFromMergeCell(mergeCell),
 	} {
 		fn[name] = js.FuncOf(impl)
 	}
@@ -2061,6 +2073,31 @@ func GetHeaderFooter(f *excelize.File) func(this js.Value, args []js.Value) inte
 	}
 }
 
+// GetMergeCells provides a function to get all merged cells from a specific worksheet.
+func GetMergeCells(f *excelize.File) func(this js.Value, args []js.Value) interface{} {
+	return func(this js.Value, args []js.Value) interface{} {
+		ret := map[string]interface{}{"mergeCells": []interface{}{}, "error": nil}
+		if err := prepareArgs(args, []argsRule{
+			{types: []js.Type{js.TypeString}},
+		}); err != nil {
+			ret["error"] = err.Error()
+			return js.ValueOf(ret)
+		}
+		mergeCells, err := f.GetMergeCells(args[0].String())
+		if err != nil {
+			ret["error"] = err.Error()
+			return js.ValueOf(ret)
+		}
+		fn := map[string]interface{}{"error": nil}
+		result := make([]interface{}, len(mergeCells))
+		for i, mergeCell := range mergeCells {
+			result[i] = regMergeCellFunc(&mergeCell, fn)
+		}
+		ret["mergeCells"] = js.ValueOf(result)
+		return js.ValueOf(ret)
+	}
+}
+
 // GetPageLayout provides a function to gets worksheet page layout.
 func GetPageLayout(f *excelize.File) func(this js.Value, args []js.Value) interface{} {
 	return func(this js.Value, args []js.Value) interface{} {
@@ -2454,6 +2491,27 @@ func GetSheetVisible(f *excelize.File) func(this js.Value, args []js.Value) inte
 			ret["error"] = err.Error()
 		}
 		return js.ValueOf(ret)
+	}
+}
+
+// GetCellValueFromMergeCell provides a function to get cell value from merge cell.
+func GetCellValueFromMergeCell(mergeCell *excelize.MergeCell) func(this js.Value, args []js.Value) interface{} {
+	return func(this js.Value, args []js.Value) interface{} {
+		return js.ValueOf(mergeCell.GetCellValue())
+	}
+}
+
+// GetStartAxisFromMergeCell provides a function to get start axis from merge cell.
+func GetStartAxisFromMergeCell(mergeCell *excelize.MergeCell) func(this js.Value, args []js.Value) interface{} {
+	return func(this js.Value, args []js.Value) interface{} {
+		return js.ValueOf(mergeCell.GetStartAxis())
+	}
+}
+
+// GetEndAxisFromMergeCell provides a function to get end axis from merge cell.
+func GetEndAxisFromMergeCell(mergeCell *excelize.MergeCell) func(this js.Value, args []js.Value) interface{} {
+	return func(this js.Value, args []js.Value) interface{} {
+		return js.ValueOf(mergeCell.GetEndAxis())
 	}
 }
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1191,6 +1191,7 @@ func TestGetMergeCells(t *testing.T) {
 	assert.True(t, f.(js.Value).Get("error").IsNull())
 
 	ret := f.(js.Value).Call("SetCellValue", js.ValueOf("Sheet1"), js.ValueOf("A1"), js.ValueOf("value"))
+	assert.True(t, ret.Get("error").IsNull())
 
 	ret = f.(js.Value).Call("MergeCell", js.ValueOf("Sheet1"), js.ValueOf("A1"), js.ValueOf("C3"))
 	assert.True(t, ret.Get("error").IsNull())
@@ -1198,11 +1199,20 @@ func TestGetMergeCells(t *testing.T) {
 	ret = f.(js.Value).Call("GetMergeCells", js.ValueOf("Sheet1"))
 	assert.True(t, ret.Get("error").IsNull())
 
-	var mergeCell interface{}
-	mergeCell = ret.Get("mergeCells").Index(0)
-	assert.Equal(t, "value", mergeCell.(js.Value).Call("GetCellValue").String())
-	assert.Equal(t, "A1", mergeCell.(js.Value).Call("GetStartAxis").String())
-	assert.Equal(t, "C3", mergeCell.(js.Value).Call("GetEndAxis").String())
+	mergeCell := ret.Get("mergeCells").Index(0)
+	assert.Equal(t, "value", mergeCell.Call("GetCellValue").String())
+	assert.Equal(t, "A1", mergeCell.Call("GetStartAxis").String())
+	assert.Equal(t, "C3", mergeCell.Call("GetEndAxis").String())
+
+	ret = f.(js.Value).Call("GetMergeCells", js.ValueOf(1))
+	assert.EqualError(t, errArgType, ret.Get("error").String())
+
+	ret = f.(js.Value).Call("GetMergeCells")
+	assert.EqualError(t, errArgNum, ret.Get("error").String())
+
+	ret = f.(js.Value).Call("GetMergeCells", js.ValueOf("SheetN"))
+	assert.Equal(t, "sheet SheetN does not exist", ret.Get("error").String())
+	assert.Equal(t, 0, ret.Get("mergeCells").Length())
 }
 
 func TestGetRowHeight(t *testing.T) {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1186,6 +1186,25 @@ func TestGetDefaultFont(t *testing.T) {
 	assert.EqualError(t, errArgNum, ret.Get("error").String())
 }
 
+func TestGetMergeCells(t *testing.T) {
+	f := NewFile(js.Value{}, []js.Value{})
+	assert.True(t, f.(js.Value).Get("error").IsNull())
+
+	ret := f.(js.Value).Call("SetCellValue", js.ValueOf("Sheet1"), js.ValueOf("A1"), js.ValueOf("value"))
+
+	ret = f.(js.Value).Call("MergeCell", js.ValueOf("Sheet1"), js.ValueOf("A1"), js.ValueOf("C3"))
+	assert.True(t, ret.Get("error").IsNull())
+
+	ret = f.(js.Value).Call("GetMergeCells", js.ValueOf("Sheet1"))
+	assert.True(t, ret.Get("error").IsNull())
+
+	var mergeCell interface{}
+	mergeCell = ret.Get("mergeCells").Index(0)
+	assert.Equal(t, "value", mergeCell.(js.Value).Call("GetCellValue").String())
+	assert.Equal(t, "A1", mergeCell.(js.Value).Call("GetStartAxis").String())
+	assert.Equal(t, "C3", mergeCell.(js.Value).Call("GetEndAxis").String())
+}
+
 func TestGetRowHeight(t *testing.T) {
 	f := NewFile(js.Value{}, []js.Value{})
 	assert.True(t, f.(js.Value).Get("error").IsNull())

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -796,6 +796,12 @@ declare module 'excelize-wasm' {
     FirstFooter?:      string;
   };
 
+  export interface MergeCell {
+    GetCellValue: () => string;
+    GetStartAxis: () => string;
+    GetEndAxis: () => string;
+  }
+
   /**
    * PageLayoutOptions directly maps the settings of page layout.
    */
@@ -2140,6 +2146,12 @@ declare module 'excelize-wasm' {
      * @param sheet The worksheet name
      */
     GetHeaderFooter(sheet: string): { opts: HeaderFooterOptions, error: string | null }
+
+    /**
+     * GetMergeCells provides a function to get all merged cells from a specific worksheet.
+     * @param sheet The worksheet name
+     */
+    GetMergeCells(sheet: string): { mergeCells: Array<MergeCell>, error: string | null }
 
     /**
      * GetPageLayout provides a function to gets worksheet page layout.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -796,11 +796,14 @@ declare module 'excelize-wasm' {
     FirstFooter?:      string;
   };
 
+  /**
+   * MergeCell define a merged cell data.
+   */
   export interface MergeCell {
     GetCellValue: () => string;
     GetStartAxis: () => string;
     GetEndAxis: () => string;
-  }
+  };
 
   /**
    * PageLayoutOptions directly maps the settings of page layout.
@@ -2148,10 +2151,11 @@ declare module 'excelize-wasm' {
     GetHeaderFooter(sheet: string): { opts: HeaderFooterOptions, error: string | null }
 
     /**
-     * GetMergeCells provides a function to get all merged cells from a specific worksheet.
+     * GetMergeCells provides a function to get all merged cells from a specific
+     * worksheet.
      * @param sheet The worksheet name
      */
-    GetMergeCells(sheet: string): { mergeCells: Array<MergeCell>, error: string | null }
+    GetMergeCells(sheet: string): { mergeCells: MergeCell[], error: string | null }
 
     /**
      * GetPageLayout provides a function to gets worksheet page layout.


### PR DESCRIPTION
# PR Details

- A new function GetMergeCells has been added

## Description

GetMergeCells provides a function to get merged cells from a specific worksheet.

## Related Issue

None

## Motivation and Context

Currently, the wasm package lacks the API to obtain the merged cells.

## How Has This Been Tested

Add unit unit tests and existing test case passed

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
