### PR TITLE
Allow to work in web workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 
 # Intermediate and distribution artifacts
 dist/
+.devcontainer/devcontainer.json

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ node_modules/
 
 # Intermediate and distribution artifacts
 dist/
-.devcontainer/devcontainer.json

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,17 @@
-!globalThis.crypto && (globalThis.crypto = {
-  async getRandomValues(b) {
-    const { randomFillSync } = await import('crypto');
-    randomFillSync(b);
-  }
-});
-!globalThis.performance && (globalThis.performance = {
-  now() {
-    const [sec, nsec] = process.hrtime();
-    return sec * 1000 + nsec / 1000000;
-  }
-});
+if (typeof globalThis.navigator === 'undefined') {
+  !globalThis.crypto && (globalThis.crypto = {
+    async getRandomValues(b) {
+      const { randomFillSync } = await import('crypto');
+      randomFillSync(b);
+    }
+  });
+  !globalThis.performance && (globalThis.performance = {
+    now() {
+      const [sec, nsec] = process.hrtime();
+      return sec * 1000 + nsec / 1000000;
+    }
+  });
+}
 (() => {
   const enosys = () => {
     const err = new Error("not implemented");
@@ -570,7 +572,7 @@ import pako from 'pako';
 export async function init(wasmPath) {
   const go = new Go();
   var buffer;
-  if (fs && fs.readFileSync) {
+  if (typeof globalThis.navigator === 'undefined') {
     globalThis.excelize = {};
     const fs = await import('fs');
     buffer = pako.ungzip(fs.readFileSync(wasmPath));
@@ -585,4 +587,3 @@ export async function init(wasmPath) {
   go.run(result.instance);
   return excelize;
 };
-

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 if (typeof window === 'undefined') {
-  !global.crypto && (global.crypto = {
+  !globalThis.crypto && (globalThis.crypto = {
     async getRandomValues(b) {
       const { randomFillSync } = await import('crypto');
       randomFillSync(b);
     }
   });
-  !global.performance && (global.performance = {
+  !globalThis.performance && (globalThis.performance = {
     now() {
       const [sec, nsec] = process.hrtime();
       return sec * 1000 + nsec / 1000000;
@@ -572,12 +572,12 @@ import pako from 'pako';
 export async function init(wasmPath) {
   const go = new Go();
   var buffer;
-  if (typeof window === 'undefined') {
-    global.excelize = {};
+  if (fs && fs.readFileSync) {
+    globalThis.excelize = {};
     const fs = await import('fs');
     buffer = pako.ungzip(fs.readFileSync(wasmPath));
   } else {
-    window.excelize = {};
+    globalThis.excelize = {};
     buffer = pako.ungzip(await (await fetch(wasmPath)).arrayBuffer());
   }
   if (buffer[0] === 0x1f && buffer[1] === 0x8b) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,15 @@
-if (typeof window === 'undefined') {
-  !globalThis.crypto && (globalThis.crypto = {
-    async getRandomValues(b) {
-      const { randomFillSync } = await import('crypto');
-      randomFillSync(b);
-    }
-  });
-  !globalThis.performance && (globalThis.performance = {
-    now() {
-      const [sec, nsec] = process.hrtime();
-      return sec * 1000 + nsec / 1000000;
-    }
-  });
-}
+!globalThis.crypto && (globalThis.crypto = {
+  async getRandomValues(b) {
+    const { randomFillSync } = await import('crypto');
+    randomFillSync(b);
+  }
+});
+!globalThis.performance && (globalThis.performance = {
+  now() {
+    const [sec, nsec] = process.hrtime();
+    return sec * 1000 + nsec / 1000000;
+  }
+});
 (() => {
   const enosys = () => {
     const err = new Error("not implemented");
@@ -581,7 +579,7 @@ export async function init(wasmPath) {
     buffer = pako.ungzip(await (await fetch(wasmPath)).arrayBuffer());
   }
   if (buffer[0] === 0x1f && buffer[1] === 0x8b) {
-      buffer = pako.ungzip(buffer);
+    buffer = pako.ungzip(buffer);
   }
   const result = await WebAssembly.instantiate(buffer, go.importObject);
   go.run(result.instance);


### PR DESCRIPTION
# PR Details

## Description

Previous version was using typeof window === 'undefined' to test if the running environment is Node or browser, but the window object doesn't exists in web worker env, which is in browser anyway...
This PR use globalThis to test if polyfills needs to be set

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/xuri/excelize-wasm/issues/34

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Quick test in browser env with web worker

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
